### PR TITLE
failing test for #8

### DIFF
--- a/test/index.js
+++ b/test/index.js
@@ -119,5 +119,35 @@ describe('gulp-exec', function() {
 			stream.end();
 		});
 
+		it('should not exit if command results in error status', function(done) {
+			// Arrange
+			var ext = 'out';
+			var base = path.join(__dirname, '../');
+			var tempFile = path.join(base, './temp.txt');
+			var relative = 'temp.txt';
+			var fakeFile = new gutil.File({
+				base: base,
+				cwd: base,
+				path: tempFile,
+				contents: new Buffer(tempFileContent)
+			});
+
+			fs.writeFileSync(tempFile, tempFileContent);
+			fs.existsSync(tempFile).should.equal(true);
+
+			var stream = exec('exit 2', {ext: ext});
+
+			// Assert
+			stream.once('end', function(){
+				// Test that command executed
+				true.should.be.ok;
+				done();
+			});
+
+			// Act
+			stream.write(fakeFile);
+			stream.end();
+		});
+
 	});
 });


### PR DESCRIPTION
actually errors the test suite, since there's not a place to catch the
exception AFAIK
