### PR TITLE
added option for piping the command output to the file

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,6 +21,10 @@ module.exports = function(command, opt){
 		opt.continueOnError = false;
 	}
 
+    if (typeof opt.pipeStdout === 'undefined') {
+        opt.pipeStdout = false;
+    }
+
 	return map(function (file, cb){
 		var cmd = gutil.template(command, {file: file, options: opt});
 
@@ -31,9 +35,12 @@ module.exports = function(command, opt){
 			if (stdout) {
 				stdout = stdout.trim(); // Trim trailing cr-lf
 			}
-			if (!opt.silent && stdout) {
+			if (!opt.silent && !opt.pipeStdout && stdout) {
 				gutil.log(stdout);
 			}
+            if (opt.pipeStdout) {
+                file.contents = new Buffer(stdout);
+            }
 			cb(opt.continueOnError ? null : error, file);
 		});
 	});

--- a/test/index.js
+++ b/test/index.js
@@ -142,5 +142,30 @@ describe('gulp-exec', function() {
 			stream.end();
 		});
 
+        it('should pass the command output with pipeStdout', function (done) {
+            // Arrange
+			var fakeFile = new gutil.File({
+                contents: new Buffer(""),
+			});
+            var cmd = "echo test";
+
+            var stream = exec(cmd, {pipeStdout: true});
+
+            var output = '';
+            stream.on('data', function (file) {
+                output = file.contents.toString();
+            });
+
+            // Assert
+            stream.on('end', function () {
+                output.should.equal("test");
+                done();
+            });
+
+            // Act
+            stream.write(fakeFile);
+            stream.end();
+        })
+
 	});
 });


### PR DESCRIPTION
I added an option to replace the file contents with the stdout of the command. I considered passing either the file name or contents as stdin to the command, but child_process.exec doesn't support setting the stdin.
