### PR TITLE
Fix documentation to avoid the Gulp 4.0 error

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ gulp.task('reset', function() {
   	stderr: true, // default = true, false means don't write stderr
   	stdout: true // default = true, false means don't write stdout
   }
-  gulp.src('./**/**')
+  return gulp.src('./**/**')
     .pipe(exec('git checkout <%= file.path %> <%= options.customTemplatingThing %>', options))
     .pipe(exec.reporter(reportOptions));
 });


### PR DESCRIPTION
Without the `return`, gulp-4.0 outputs
```
[16:46:43] The following tasks did not complete: <my-task>
[16:46:43] Did you forget to signal async completion?
```