### PR TITLE
Add options.childProcess

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ gulp.task('reset', function() {
     continueOnError: false, // default = false, true means don't emit error event
     pipeStdout: false, // default = false, true means stdout is written to file.contents
     customTemplatingThing: "test" // content passed to gutil.template()
+    // options.childProcess will be set to ChildProcess object resulting from exec()
   };
   var reportOptions = {
   	err: true, // default = true, false means don't write err

--- a/index.js
+++ b/index.js
@@ -31,7 +31,7 @@ function doExec(command, opt){
 		var cmd = gutil.template(command, {file: file, options: opt});
 		var that = this;
 
-		exec(cmd, opt, function (err, stdout, stderr) {
+		opt.childProcess = exec(cmd, opt, function (err, stdout, stderr) {
 			file.exec = {
 				err: err,
 				stdout: stdout.trim(),


### PR DESCRIPTION
No option has to be set beforehand, but `options.childProcess` will be set to the result of your plugin's `child_process.exec()`. This way I can send a kill signal to the process later, etc.