### PR TITLE
Fixed Path Appending Issue

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,7 +27,7 @@ function doExec(command, opt){
 	// Include node_modules/.bin on the path when we execute the command.
 	var oldPath = opt.env.PATH;
 	var newPath = path.join(__dirname, '..', '..', '.bin');
-	var regExp = new RegExp("(^|" + escapeRegExp(path.delimiter) + ")" + escapeRegExp(newPath) + "(" + escapeRegExp(path.delimiter) + "|$");
+	var regExp = new RegExp("(^|" + escapeRegExp(path.delimiter) + ")" + escapeRegExp(newPath) + "(" + escapeRegExp(path.delimiter) + "|$)");
 	if (!regExp.exec(oldPath)) {
 		newPath += path.delimiter;
 		newPath += oldPath;

--- a/index.js
+++ b/index.js
@@ -27,7 +27,7 @@ function doExec(command, opt){
 	// Include node_modules/.bin on the path when we execute the command.
 	var oldPath = opt.env.PATH;
 	var newPath = path.join(__dirname, '..', '..', '.bin');
-	var regExp = new RegExp(`(^|${escapeRegExp(path.delimiter)})${escapeRegExp(newPath)}(${escapeRegExp(path.delimiter)}|$)`);
+	var regExp = new RegExp("(^|" + escapeRegExp(path.delimiter) + ")" + escapeRegExp(newPath) + "(" + escapeRegExp(path.delimiter) + "|$");
 	if (!regExp.exec(oldPath)) {
 		newPath += path.delimiter;
 		newPath += oldPath;

--- a/index.js
+++ b/index.js
@@ -7,6 +7,10 @@ var exec = require('child_process').exec;
 
 var PLUGIN_NAME = 'gulp-exec';
 
+function escapeRegExp(val) {
+	return val.replace(/[-\/\\^$*+?.()|[\]{}]/g, '\\$&')
+}
+
 function doExec(command, opt){
 	if (!command) {
 		throw new Error('command is blank');
@@ -23,9 +27,12 @@ function doExec(command, opt){
 	// Include node_modules/.bin on the path when we execute the command.
 	var oldPath = opt.env.PATH;
 	var newPath = path.join(__dirname, '..', '..', '.bin');
-	newPath += path.delimiter;
-	newPath += oldPath;
-	opt.env.PATH = newPath;
+	var regExp = new RegExp(`(^|${escapeRegExp(path.delimiter)})${escapeRegExp(newPath)}(${escapeRegExp(path.delimiter)}|$)`);
+	if (!regExp.exec(oldPath)) {
+		newPath += path.delimiter;
+		newPath += oldPath;
+		opt.env.PATH = newPath;
+	}
 
 	return through2.obj(function (file, enc, cb){
 		var cmd = gutil.template(command, {file: file, options: opt});


### PR DESCRIPTION
The bin folder path get's pre-pended to the system path each time exec is called.  This causes an issue in Windows when you call exec multiple times in the same script.  Windows only allows 4095 characters on the path, so if you call exec multiple times you end up cutting off everything else. This change just adds a check to see if the folder is already in the path before pre-pending it.

