### PR TITLE
Replace lodash.template with function

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -1,4 +1,5 @@
 {
+    "esversion": 6,
     "bitwise": true,
     "camelcase": true,
     "curly": true,

--- a/README.md
+++ b/README.md
@@ -13,7 +13,6 @@ gulp.task('reset', function() {
   var options = {
     continueOnError: false, // default = false, true means don't emit error event
     pipeStdout: false, // default = false, true means stdout is written to file.contents
-    customTemplatingThing: "test" // content passed to lodash.template()
   };
   var reportOptions = {
   	err: true, // default = true, false means don't write err
@@ -21,7 +20,7 @@ gulp.task('reset', function() {
   	stdout: true // default = true, false means don't write stdout
   };
   return gulp.src('./**/**')
-    .pipe(exec('git checkout <%= file.path %> <%= options.customTemplatingThing %>', options))
+    .pipe(exec((file) => `git checkout ${file.path} test`, options))
     .pipe(exec.reporter(reportOptions));
 });
 ```

--- a/index.js
+++ b/index.js
@@ -2,7 +2,6 @@
 
 var through2 = require('through2');
 var PluginError = require('plugin-error');
-var template = require('lodash.template');
 var exec = require('child_process').exec;
 var prependPath = require('./prependPath');
 
@@ -24,7 +23,7 @@ function doExec(command, opt){
 	prependPath(opt.env);
 
 	return through2.obj(function (file, enc, cb){
-		var cmd = template(command)({file: file, options: opt});
+		var cmd = typeof command === 'function' ? command(file) : command;
 		var that = this;
 
 		exec(cmd, opt, function (err, stdout, stderr) {

--- a/index.js
+++ b/index.js
@@ -35,7 +35,7 @@ function doExec(command, opt){
 			};
 			if (opt.pipeStdout) {
 				file.exec.contents = file.contents;
-				file.contents = new Buffer(stdout, opt.encoding); // FRAGILE: if it wasn't a buffer it is now				
+				file.contents = Buffer.from(stdout, opt.encoding); // FRAGILE: if it wasn't a buffer it is now
 			}
 			if (err && !opt.continueOnError) {
 				that.emit('error', new PluginError(PLUGIN_NAME, err));

--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
     "exec"
   ],
   "dependencies": {
-    "lodash.template": "^4.4.0",
     "plugin-error": "^1.0.1",
     "through2": "^3.0.1"
   },

--- a/test/index.js
+++ b/test/index.js
@@ -11,268 +11,268 @@ var fs = require('fs');
 var should = require('should');
 
 describe('gulp-exec', function() {
-  describe('exec()', function() {
-    var tempFileContent = 'A test generated this file and it is safe to delete';
-    var tempBinaryFileContent = '\x89';
-    var realPath = process.env.PATH;
+	describe('exec()', function() {
+		var tempFileContent = 'A test generated this file and it is safe to delete';
+		var tempBinaryFileContent = '\x89';
+		var realPath = process.env.PATH;
 
-    afterEach(function () {
-      process.env.PATH = realPath;
-    });
+		afterEach(function () {
+			process.env.PATH = realPath;
+		});
 
-    it('should pass file structure through', function(done) {
-      // arrange
-      var base = path.join(__dirname, '../');
-      var tempFile = path.join(base, './temp.txt');
-      var relative = 'temp.txt';
-      var fakeFile = new Vinyl({
-        base: base,
-        cwd: base,
-        path: tempFile,
-        contents: Buffer.from(tempFileContent)
-      });
+		it('should pass file structure through', function(done) {
+			// arrange
+			var base = path.join(__dirname, '../');
+			var tempFile = path.join(base, './temp.txt');
+			var relative = 'temp.txt';
+			var fakeFile = new Vinyl({
+				base: base,
+				cwd: base,
+				path: tempFile,
+				contents: Buffer.from(tempFileContent)
+			});
 
-      var stream = exec('echo hi');
+			var stream = exec('echo hi');
 
-      // assert
-      stream.on('data', function(actualFile){
-        // Test that content passed through
-        should.exist(actualFile);
-        should.exist(actualFile.path);
-        should.exist(actualFile.relative);
-        should.exist(actualFile.contents);
-        actualFile.path.should.equal(tempFile);
-        actualFile.relative.should.equal(relative);
-        String(actualFile.contents).should.equal(tempFileContent);
-        done();
-      });
+			// assert
+			stream.on('data', function(actualFile){
+				// Test that content passed through
+				should.exist(actualFile);
+				should.exist(actualFile.path);
+				should.exist(actualFile.relative);
+				should.exist(actualFile.contents);
+				actualFile.path.should.equal(tempFile);
+				actualFile.relative.should.equal(relative);
+				String(actualFile.contents).should.equal(tempFileContent);
+				done();
+			});
 
-      // act
-      stream.write(fakeFile);
-      stream.end();
-    });
+			// act
+			stream.write(fakeFile);
+			stream.end();
+		});
 
-    it('should execute a command with options and templating', function(done) {
-      // arrange
-      var ext = 'out';
-      var base = path.join(__dirname, '../');
-      var tempFile = path.join(base, './temp.txt');
-      var fakeFile = new Vinyl({
-        base: base,
-        cwd: base,
-        path: tempFile,
-        contents: Buffer.from(tempFileContent)
-      });
+		it('should execute a command with options and templating', function(done) {
+			// arrange
+			var ext = 'out';
+			var base = path.join(__dirname, '../');
+			var tempFile = path.join(base, './temp.txt');
+			var fakeFile = new Vinyl({
+				base: base,
+				cwd: base,
+				path: tempFile,
+				contents: Buffer.from(tempFileContent)
+			});
 
-      fs.writeFileSync(tempFile, tempFileContent);
-      fs.existsSync(tempFile).should.equal(true);
+			fs.writeFileSync(tempFile, tempFileContent);
+			fs.existsSync(tempFile).should.equal(true);
 
-      var stream = exec(({ path }) => `cp "${path}" "${path}.${ext}"`);
+			var stream = exec(({ path }) => `cp "${path}" "${path}.${ext}"`);
 
-      // assert
-      stream.once('finish', function(){
-        // Test that command executed
-        fs.existsSync(tempFile+'.'+ext).should.equal(true);
-        done();
-      });
+			// assert
+			stream.once('finish', function(){
+				// Test that command executed
+				fs.existsSync(tempFile+'.'+ext).should.equal(true);
+				done();
+			});
 
-      // act
-      stream.write(fakeFile);
-      stream.end();
-    });
+			// act
+			stream.write(fakeFile);
+			stream.end();
+		});
 
-    it('should error on invalid command', function(done) {
-      // arrange
-      var base = path.join(__dirname, '../');
-      var tempFile = path.join(base, './temp.txt');
-      var fakeFile = new Vinyl({
-        base: base,
-        cwd: base,
-        path: tempFile,
-        contents: Buffer.from(tempFileContent)
-      });
+		it('should error on invalid command', function(done) {
+			// arrange
+			var base = path.join(__dirname, '../');
+			var tempFile = path.join(base, './temp.txt');
+			var fakeFile = new Vinyl({
+				base: base,
+				cwd: base,
+				path: tempFile,
+				contents: Buffer.from(tempFileContent)
+			});
 
-      var cmd = 'not_a_command';
+			var cmd = 'not_a_command';
 
-      var stream = exec(cmd);
+			var stream = exec(cmd);
 
-      var actualErr;
-      stream.on('error', function (err) {
-        actualErr = err;
-      });
+			var actualErr;
+			stream.on('error', function (err) {
+				actualErr = err;
+			});
 
-      stream.once('finish', function () {
+			stream.once('finish', function () {
 
-        // assert
-        should.exist(actualErr);
-        should.exist(actualErr.message);
-        actualErr.message.indexOf(cmd).should.be.above(-1);
-        done();
-      });
+				// assert
+				should.exist(actualErr);
+				should.exist(actualErr.message);
+				actualErr.message.indexOf(cmd).should.be.above(-1);
+				done();
+			});
 
-      // act
-      stream.write(fakeFile);
-      stream.end();
-    });
+			// act
+			stream.write(fakeFile);
+			stream.end();
+		});
 
-    it('should not emit error when `continueOnError == true`', function (done) {
-      // arrange
-      var base = path.join(__dirname, '../');
-      var tempFile = path.join(base, './temp.txt');
-      var fakeFile = new Vinyl({
-        base: base,
-        cwd: base,
-        path: tempFile,
-        contents: Buffer.from(tempFileContent)
-      });
+		it('should not emit error when `continueOnError == true`', function (done) {
+			// arrange
+			var base = path.join(__dirname, '../');
+			var tempFile = path.join(base, './temp.txt');
+			var fakeFile = new Vinyl({
+				base: base,
+				cwd: base,
+				path: tempFile,
+				contents: Buffer.from(tempFileContent)
+			});
 
-      var cmd = 'not_a_command';
+			var cmd = 'not_a_command';
 
-      var stream = exec(cmd, {continueOnError: true});
+			var stream = exec(cmd, {continueOnError: true});
 
-      var emitted = false;
-      stream.on('error', function () {
-        emitted = true;
-      });
+			var emitted = false;
+			stream.on('error', function () {
+				emitted = true;
+			});
 
-      // assert
-      stream.on('finish', function () {
-        emitted.should.equal(false);
-        done();
-      });
+			// assert
+			stream.on('finish', function () {
+				emitted.should.equal(false);
+				done();
+			});
 
-      // act
-      stream.write(fakeFile);
-      stream.end();
-    });
+			// act
+			stream.write(fakeFile);
+			stream.end();
+		});
 
-    it('should not exit if command results in error status', function(done) {
-      // arrange
-      var base = path.join(__dirname, '../');
-      var tempFile = path.join(base, './temp.txt');
-      var fakeFile = new Vinyl({
-        base: base,
-        cwd: base,
-        path: tempFile,
-        contents: Buffer.from(tempFileContent)
-      });
+		it('should not exit if command results in error status', function(done) {
+			// arrange
+			var base = path.join(__dirname, '../');
+			var tempFile = path.join(base, './temp.txt');
+			var fakeFile = new Vinyl({
+				base: base,
+				cwd: base,
+				path: tempFile,
+				contents: Buffer.from(tempFileContent)
+			});
 
-      var stream = exec('exit 2');
+			var stream = exec('exit 2');
 
-      var emitted = false;
-      stream.on('error', function () {
-        emitted = true;
-      });
+			var emitted = false;
+			stream.on('error', function () {
+				emitted = true;
+			});
 
-      // assert
-      stream.once('finish', function(){
-        // Test that command executed
-        // If we got here, exec didn't die
-        emitted.should.equal(true);
-        done();
-      });
+			// assert
+			stream.once('finish', function(){
+				// Test that command executed
+				// If we got here, exec didn't die
+				emitted.should.equal(true);
+				done();
+			});
 
-      // act
-      stream.write(fakeFile);
-      stream.end();
-    });
+			// act
+			stream.write(fakeFile);
+			stream.end();
+		});
 
-    it('should prepend to path', function(done) {
-      // arrange
-      var startPath = process.env.PATH;
-      var base = path.join(__dirname, '../');
-      var tempFile = path.join(base, './temp.txt');
-      var fakeFile = new Vinyl({
-        base: base,
-        cwd: base,
-        path: tempFile,
-        contents: Buffer.from(tempFileContent)
-      });
+		it('should prepend to path', function(done) {
+			// arrange
+			var startPath = process.env.PATH;
+			var base = path.join(__dirname, '../');
+			var tempFile = path.join(base, './temp.txt');
+			var fakeFile = new Vinyl({
+				base: base,
+				cwd: base,
+				path: tempFile,
+				contents: Buffer.from(tempFileContent)
+			});
 
-      var stream = exec('echo hi');
+			var stream = exec('echo hi');
 
-      // assert
-      stream.once('finish', function(){
-        // If we got here, exec didn't die
+			// assert
+			stream.once('finish', function(){
+				// If we got here, exec didn't die
 
-        // Test that path is unchanged
-        var endPath = process.env.PATH;
-        endPath.should.not.equal(startPath);
+				// Test that path is unchanged
+				var endPath = process.env.PATH;
+				endPath.should.not.equal(startPath);
 
-        done();
-      });
+				done();
+			});
 
-      // act
-      stream.write(fakeFile);
-      stream.end();
-    });
+			// act
+			stream.write(fakeFile);
+			stream.end();
+		});
 
-    it('should not prepend to path if already exists', function(done) {
-      // arrange
-      prependPath(process.env);
-      var startPath = process.env.PATH;
-      var base = path.join(__dirname, '../');
-      var tempFile = path.join(base, './temp.txt');
-      var fakeFile = new Vinyl({
-        base: base,
-        cwd: base,
-        path: tempFile,
-        contents: Buffer.from(tempFileContent)
-      });
+		it('should not prepend to path if already exists', function(done) {
+			// arrange
+			prependPath(process.env);
+			var startPath = process.env.PATH;
+			var base = path.join(__dirname, '../');
+			var tempFile = path.join(base, './temp.txt');
+			var fakeFile = new Vinyl({
+				base: base,
+				cwd: base,
+				path: tempFile,
+				contents: Buffer.from(tempFileContent)
+			});
 
-      var stream = exec('echo hi');
+			var stream = exec('echo hi');
 
-      // assert
-      stream.once('finish', function(){
-        // If we got here, exec didn't die
+			// assert
+			stream.once('finish', function(){
+				// If we got here, exec didn't die
 
-        // Test that path is changed
-        var endPath = process.env.PATH;
-        endPath.should.equal(startPath);
+				// Test that path is changed
+				var endPath = process.env.PATH;
+				endPath.should.equal(startPath);
 
-        done();
-      });
+				done();
+			});
 
-      // act
-      stream.write(fakeFile);
-      stream.end();
-    });
+			// act
+			stream.write(fakeFile);
+			stream.end();
+		});
 
-    it('should correctly handle binary data from stdout', function(done) {
-      // arrange
-      var base = path.join(__dirname, '../');
-      var tempFile = path.join(base, './temp.bin');			
-      var tempFileBuffer = Buffer.from(tempBinaryFileContent, 'binary');
-      var fakeFile = new Vinyl({
-        base: base,
-        cwd: base,
-        path: tempFile,
-        contents: tempFileBuffer
-      });
-      var options = {
-        continueOnError: false,
-        pipeStdout: true,
-        encoding: 'binary'
-      };
+		it('should correctly handle binary data from stdout', function(done) {
+			// arrange
+			var base = path.join(__dirname, '../');
+			var tempFile = path.join(base, './temp.bin');			
+			var tempFileBuffer = Buffer.from(tempBinaryFileContent, 'binary');
+			var fakeFile = new Vinyl({
+				base: base,
+				cwd: base,
+				path: tempFile,
+				contents: tempFileBuffer
+			});
+			var options = {
+				continueOnError: false,
+				pipeStdout: true,
+				encoding: 'binary'
+			};
 
-      fs.writeFileSync(tempFile, tempFileBuffer, 'binary');
-      fs.existsSync(tempFile).should.equal(true);
+			fs.writeFileSync(tempFile, tempFileBuffer, 'binary');
+			fs.existsSync(tempFile).should.equal(true);
 
-      var stream = exec(({ path }) => `cat "${path}"`, options);
+			var stream = exec(({ path }) => `cat "${path}"`, options);
 
-      // assert
-      stream.on('data', function(result){
-        should.exist(result);
-        should.exist(result.contents);
-        var isBuffersEqual = result.contents.equals(tempFileBuffer);
-        isBuffersEqual.should.equal(true);				
-        done();
-      });
+			// assert
+			stream.on('data', function(result){
+				should.exist(result);
+				should.exist(result.contents);
+				var isBuffersEqual = result.contents.equals(tempFileBuffer);
+				isBuffersEqual.should.equal(true);				
+				done();
+			});
 
-      // act
-      stream.write(fakeFile);
-      stream.end();
-    });
+			// act
+			stream.write(fakeFile);
+			stream.end();
+		});
 
-  });
+	});
 });

--- a/test/index.js
+++ b/test/index.js
@@ -29,7 +29,7 @@ describe('gulp-exec', function() {
 				base: base,
 				cwd: base,
 				path: tempFile,
-				contents: new Buffer(tempFileContent)
+				contents: Buffer.from(tempFileContent)
 			});
 
 			var stream = exec('echo hi');
@@ -61,7 +61,7 @@ describe('gulp-exec', function() {
 				base: base,
 				cwd: base,
 				path: tempFile,
-				contents: new Buffer(tempFileContent)
+				contents: Buffer.from(tempFileContent)
 			});
 
 			fs.writeFileSync(tempFile, tempFileContent);
@@ -89,7 +89,7 @@ describe('gulp-exec', function() {
 				base: base,
 				cwd: base,
 				path: tempFile,
-				contents: new Buffer(tempFileContent)
+				contents: Buffer.from(tempFileContent)
 			});
 
 			var cmd = 'not_a_command';
@@ -123,7 +123,7 @@ describe('gulp-exec', function() {
 				base: base,
 				cwd: base,
 				path: tempFile,
-				contents: new Buffer(tempFileContent)
+				contents: Buffer.from(tempFileContent)
 			});
 
 			var cmd = 'not_a_command';
@@ -155,7 +155,7 @@ describe('gulp-exec', function() {
 				base: base,
 				cwd: base,
 				path: tempFile,
-				contents: new Buffer(tempFileContent)
+				contents: Buffer.from(tempFileContent)
 			});
 
 			var stream = exec('exit 2', {ext: ext});
@@ -187,7 +187,7 @@ describe('gulp-exec', function() {
 				base: base,
 				cwd: base,
 				path: tempFile,
-				contents: new Buffer(tempFileContent)
+				contents: Buffer.from(tempFileContent)
 			});
 
 			var stream = exec('echo hi');
@@ -218,7 +218,7 @@ describe('gulp-exec', function() {
 				base: base,
 				cwd: base,
 				path: tempFile,
-				contents: new Buffer(tempFileContent)
+				contents: Buffer.from(tempFileContent)
 			});
 
 			var stream = exec('echo hi');
@@ -243,7 +243,7 @@ describe('gulp-exec', function() {
 			// arrange
 			var base = path.join(__dirname, '../');
 			var tempFile = path.join(base, './temp.bin');			
-			var tempFileBuffer = new Buffer(tempBinaryFileContent, 'binary');
+			var tempFileBuffer = Buffer.from(tempBinaryFileContent, 'binary');
 			var fakeFile = new Vinyl({
 				base: base,
 				cwd: base,

--- a/test/index.js
+++ b/test/index.js
@@ -11,269 +11,268 @@ var fs = require('fs');
 var should = require('should');
 
 describe('gulp-exec', function() {
-	describe('exec()', function() {
-		var tempFileContent = 'A test generated this file and it is safe to delete';
-		var tempBinaryFileContent = '\x89';
-		var realPath = process.env.PATH;
+  describe('exec()', function() {
+    var tempFileContent = 'A test generated this file and it is safe to delete';
+    var tempBinaryFileContent = '\x89';
+    var realPath = process.env.PATH;
 
-		afterEach(function () {
-			process.env.PATH = realPath;
-		});
+    afterEach(function () {
+      process.env.PATH = realPath;
+    });
 
-		it('should pass file structure through', function(done) {
-			// arrange
-			var base = path.join(__dirname, '../');
-			var tempFile = path.join(base, './temp.txt');
-			var relative = 'temp.txt';
-			var fakeFile = new Vinyl({
-				base: base,
-				cwd: base,
-				path: tempFile,
-				contents: Buffer.from(tempFileContent)
-			});
+    it('should pass file structure through', function(done) {
+      // arrange
+      var base = path.join(__dirname, '../');
+      var tempFile = path.join(base, './temp.txt');
+      var relative = 'temp.txt';
+      var fakeFile = new Vinyl({
+        base: base,
+        cwd: base,
+        path: tempFile,
+        contents: Buffer.from(tempFileContent)
+      });
 
-			var stream = exec('echo hi');
+      var stream = exec('echo hi');
 
-			// assert
-			stream.on('data', function(actualFile){
-				// Test that content passed through
-				should.exist(actualFile);
-				should.exist(actualFile.path);
-				should.exist(actualFile.relative);
-				should.exist(actualFile.contents);
-				actualFile.path.should.equal(tempFile);
-				actualFile.relative.should.equal(relative);
-				String(actualFile.contents).should.equal(tempFileContent);
-				done();
-			});
+      // assert
+      stream.on('data', function(actualFile){
+        // Test that content passed through
+        should.exist(actualFile);
+        should.exist(actualFile.path);
+        should.exist(actualFile.relative);
+        should.exist(actualFile.contents);
+        actualFile.path.should.equal(tempFile);
+        actualFile.relative.should.equal(relative);
+        String(actualFile.contents).should.equal(tempFileContent);
+        done();
+      });
 
-			// act
-			stream.write(fakeFile);
-			stream.end();
-		});
+      // act
+      stream.write(fakeFile);
+      stream.end();
+    });
 
-		it('should execute a command with options and templating', function(done) {
-			// arrange
-			var ext = 'out';
-			var base = path.join(__dirname, '../');
-			var tempFile = path.join(base, './temp.txt');
-			var fakeFile = new Vinyl({
-				base: base,
-				cwd: base,
-				path: tempFile,
-				contents: Buffer.from(tempFileContent)
-			});
+    it('should execute a command with options and templating', function(done) {
+      // arrange
+      var ext = 'out';
+      var base = path.join(__dirname, '../');
+      var tempFile = path.join(base, './temp.txt');
+      var fakeFile = new Vinyl({
+        base: base,
+        cwd: base,
+        path: tempFile,
+        contents: Buffer.from(tempFileContent)
+      });
 
-			fs.writeFileSync(tempFile, tempFileContent);
-			fs.existsSync(tempFile).should.equal(true);
+      fs.writeFileSync(tempFile, tempFileContent);
+      fs.existsSync(tempFile).should.equal(true);
 
-			var stream = exec('cp "<%= file.path %>" "<%= file.path %>.<%= options.ext %>"', {ext: ext});
+      var stream = exec(({ path }) => `cp "${path}" "${path}.${ext}"`);
 
-			// assert
-			stream.once('finish', function(){
-				// Test that command executed
-				fs.existsSync(tempFile+'.'+ext).should.equal(true);
-				done();
-			});
+      // assert
+      stream.once('finish', function(){
+        // Test that command executed
+        fs.existsSync(tempFile+'.'+ext).should.equal(true);
+        done();
+      });
 
-			// act
-			stream.write(fakeFile);
-			stream.end();
-		});
+      // act
+      stream.write(fakeFile);
+      stream.end();
+    });
 
-		it('should error on invalid command', function(done) {
-			// arrange
-			var base = path.join(__dirname, '../');
-			var tempFile = path.join(base, './temp.txt');
-			var fakeFile = new Vinyl({
-				base: base,
-				cwd: base,
-				path: tempFile,
-				contents: Buffer.from(tempFileContent)
-			});
+    it('should error on invalid command', function(done) {
+      // arrange
+      var base = path.join(__dirname, '../');
+      var tempFile = path.join(base, './temp.txt');
+      var fakeFile = new Vinyl({
+        base: base,
+        cwd: base,
+        path: tempFile,
+        contents: Buffer.from(tempFileContent)
+      });
 
-			var cmd = 'not_a_command';
+      var cmd = 'not_a_command';
 
-			var stream = exec(cmd);
+      var stream = exec(cmd);
 
-			var actualErr;
-			stream.on('error', function (err) {
-				actualErr = err;
-			});
+      var actualErr;
+      stream.on('error', function (err) {
+        actualErr = err;
+      });
 
-			stream.once('finish', function () {
+      stream.once('finish', function () {
 
-				// assert
-				should.exist(actualErr);
-				should.exist(actualErr.message);
-				actualErr.message.indexOf(cmd).should.be.above(-1);
-				done();
-			});
+        // assert
+        should.exist(actualErr);
+        should.exist(actualErr.message);
+        actualErr.message.indexOf(cmd).should.be.above(-1);
+        done();
+      });
 
-			// act
-			stream.write(fakeFile);
-			stream.end();
-		});
+      // act
+      stream.write(fakeFile);
+      stream.end();
+    });
 
-		it('should not emit error when `continueOnError == true`', function (done) {
-			// arrange
-			var base = path.join(__dirname, '../');
-			var tempFile = path.join(base, './temp.txt');
-			var fakeFile = new Vinyl({
-				base: base,
-				cwd: base,
-				path: tempFile,
-				contents: Buffer.from(tempFileContent)
-			});
+    it('should not emit error when `continueOnError == true`', function (done) {
+      // arrange
+      var base = path.join(__dirname, '../');
+      var tempFile = path.join(base, './temp.txt');
+      var fakeFile = new Vinyl({
+        base: base,
+        cwd: base,
+        path: tempFile,
+        contents: Buffer.from(tempFileContent)
+      });
 
-			var cmd = 'not_a_command';
+      var cmd = 'not_a_command';
 
-			var stream = exec(cmd, {continueOnError: true});
+      var stream = exec(cmd, {continueOnError: true});
 
-			var emitted = false;
-			stream.on('error', function () {
-				emitted = true;
-			});
+      var emitted = false;
+      stream.on('error', function () {
+        emitted = true;
+      });
 
-			// assert
-			stream.on('finish', function () {
-				emitted.should.equal(false);
-				done();
-			});
+      // assert
+      stream.on('finish', function () {
+        emitted.should.equal(false);
+        done();
+      });
 
-			// act
-			stream.write(fakeFile);
-			stream.end();
-		});
+      // act
+      stream.write(fakeFile);
+      stream.end();
+    });
 
-		it('should not exit if command results in error status', function(done) {
-			// arrange
-			var ext = 'out';
-			var base = path.join(__dirname, '../');
-			var tempFile = path.join(base, './temp.txt');
-			var fakeFile = new Vinyl({
-				base: base,
-				cwd: base,
-				path: tempFile,
-				contents: Buffer.from(tempFileContent)
-			});
+    it('should not exit if command results in error status', function(done) {
+      // arrange
+      var base = path.join(__dirname, '../');
+      var tempFile = path.join(base, './temp.txt');
+      var fakeFile = new Vinyl({
+        base: base,
+        cwd: base,
+        path: tempFile,
+        contents: Buffer.from(tempFileContent)
+      });
 
-			var stream = exec('exit 2', {ext: ext});
+      var stream = exec('exit 2');
 
-			var emitted = false;
-			stream.on('error', function () {
-				emitted = true;
-			});
+      var emitted = false;
+      stream.on('error', function () {
+        emitted = true;
+      });
 
-			// assert
-			stream.once('finish', function(){
-				// Test that command executed
-				// If we got here, exec didn't die
-				emitted.should.equal(true);
-				done();
-			});
+      // assert
+      stream.once('finish', function(){
+        // Test that command executed
+        // If we got here, exec didn't die
+        emitted.should.equal(true);
+        done();
+      });
 
-			// act
-			stream.write(fakeFile);
-			stream.end();
-		});
+      // act
+      stream.write(fakeFile);
+      stream.end();
+    });
 
-		it('should prepend to path', function(done) {
-			// arrange
-			var startPath = process.env.PATH;
-			var base = path.join(__dirname, '../');
-			var tempFile = path.join(base, './temp.txt');
-			var fakeFile = new Vinyl({
-				base: base,
-				cwd: base,
-				path: tempFile,
-				contents: Buffer.from(tempFileContent)
-			});
+    it('should prepend to path', function(done) {
+      // arrange
+      var startPath = process.env.PATH;
+      var base = path.join(__dirname, '../');
+      var tempFile = path.join(base, './temp.txt');
+      var fakeFile = new Vinyl({
+        base: base,
+        cwd: base,
+        path: tempFile,
+        contents: Buffer.from(tempFileContent)
+      });
 
-			var stream = exec('echo hi');
+      var stream = exec('echo hi');
 
-			// assert
-			stream.once('finish', function(){
-				// If we got here, exec didn't die
+      // assert
+      stream.once('finish', function(){
+        // If we got here, exec didn't die
 
-				// Test that path is unchanged
-				var endPath = process.env.PATH;
-				endPath.should.not.equal(startPath);
+        // Test that path is unchanged
+        var endPath = process.env.PATH;
+        endPath.should.not.equal(startPath);
 
-				done();
-			});
+        done();
+      });
 
-			// act
-			stream.write(fakeFile);
-			stream.end();
-		});
+      // act
+      stream.write(fakeFile);
+      stream.end();
+    });
 
-		it('should not prepend to path if already exists', function(done) {
-			// arrange
-			prependPath(process.env);
-			var startPath = process.env.PATH;
-			var base = path.join(__dirname, '../');
-			var tempFile = path.join(base, './temp.txt');
-			var fakeFile = new Vinyl({
-				base: base,
-				cwd: base,
-				path: tempFile,
-				contents: Buffer.from(tempFileContent)
-			});
+    it('should not prepend to path if already exists', function(done) {
+      // arrange
+      prependPath(process.env);
+      var startPath = process.env.PATH;
+      var base = path.join(__dirname, '../');
+      var tempFile = path.join(base, './temp.txt');
+      var fakeFile = new Vinyl({
+        base: base,
+        cwd: base,
+        path: tempFile,
+        contents: Buffer.from(tempFileContent)
+      });
 
-			var stream = exec('echo hi');
+      var stream = exec('echo hi');
 
-			// assert
-			stream.once('finish', function(){
-				// If we got here, exec didn't die
+      // assert
+      stream.once('finish', function(){
+        // If we got here, exec didn't die
 
-				// Test that path is changed
-				var endPath = process.env.PATH;
-				endPath.should.equal(startPath);
+        // Test that path is changed
+        var endPath = process.env.PATH;
+        endPath.should.equal(startPath);
 
-				done();
-			});
+        done();
+      });
 
-			// act
-			stream.write(fakeFile);
-			stream.end();
-		});
+      // act
+      stream.write(fakeFile);
+      stream.end();
+    });
 
-		it('should correctly handle binary data from stdout', function(done) {
-			// arrange
-			var base = path.join(__dirname, '../');
-			var tempFile = path.join(base, './temp.bin');			
-			var tempFileBuffer = Buffer.from(tempBinaryFileContent, 'binary');
-			var fakeFile = new Vinyl({
-				base: base,
-				cwd: base,
-				path: tempFile,
-				contents: tempFileBuffer
-			});
-			var options = {
-				continueOnError: false,
-				pipeStdout: true,
-				encoding: 'binary'
-			};
+    it('should correctly handle binary data from stdout', function(done) {
+      // arrange
+      var base = path.join(__dirname, '../');
+      var tempFile = path.join(base, './temp.bin');			
+      var tempFileBuffer = Buffer.from(tempBinaryFileContent, 'binary');
+      var fakeFile = new Vinyl({
+        base: base,
+        cwd: base,
+        path: tempFile,
+        contents: tempFileBuffer
+      });
+      var options = {
+        continueOnError: false,
+        pipeStdout: true,
+        encoding: 'binary'
+      };
 
-			fs.writeFileSync(tempFile, tempFileBuffer, 'binary');
-			fs.existsSync(tempFile).should.equal(true);
+      fs.writeFileSync(tempFile, tempFileBuffer, 'binary');
+      fs.existsSync(tempFile).should.equal(true);
 
-			var stream = exec('cat "<%= file.path %>"', options);
+      var stream = exec(({ path }) => `cat "${path}"`, options);
 
-			// assert
-			stream.on('data', function(result){				
-				should.exist(result);				
-				should.exist(result.contents);
-				var isBuffersEqual = result.contents.equals(tempFileBuffer);				
-				isBuffersEqual.should.equal(true);				
-				done();
-			});
+      // assert
+      stream.on('data', function(result){
+        should.exist(result);
+        should.exist(result.contents);
+        var isBuffersEqual = result.contents.equals(tempFileBuffer);
+        isBuffersEqual.should.equal(true);				
+        done();
+      });
 
-			// act
-			stream.write(fakeFile);
-			stream.end();
-		});
+      // act
+      stream.write(fakeFile);
+      stream.end();
+    });
 
-	});
+  });
 });

--- a/test/reporter.js
+++ b/test/reporter.js
@@ -42,7 +42,7 @@ describe('gulp-exec', function() {
 				base: base,
 				cwd: base,
 				path: tempFile,
-				contents: new Buffer(tempFileContent)
+				contents: Buffer.from(tempFileContent)
 			});
 			return fakeFile;
 		}


### PR DESCRIPTION
This enables writing tasks such as:

```js
const { task, src } = require('gulp');
const { exec } = require('gulp-exec');
const gulpif = require('gulp-if');

task('update-locale', () => src('locale/templates/LC_MESSAGES/**/*.pot')
  .pipe(
    gulpif(((file) => {
      const poFile = file.clone();
      poFile.extname = '.po';
      poFile.dirname = poFile.dirname.replace('templates', 'en');
      try {
        accessSync(poFile.path, F_OK);
        return true;
      } catch (e) {
        return false;
      }
    }),
    exec((file) => `msgmerge --update ${file.path.replace('templates', 'en').replace('.pot', '.po')} ${file.path}`)
    exec((file) => `msginit -l en -i ${file.path} -o ${file.path.replace('templates', 'en').replace('.pot', '.po')}`))
);
```

Using only `lodash` templates, these commands were impossible to build (`file.path.replace` cannot be called from the templates).

Edit: updated the example task slightly